### PR TITLE
[Fix] Code in labels not updating variables

### DIFF
--- a/arcweave/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/arcweave/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -300,13 +300,6 @@ FArcscriptTranspilerOutput UArcweaveSubsystem::TranspileCondition(const FString&
 
     try
     {
-        
-        FArcweaveBranchData CurrentBranch;
-        if (!GetBranchForObject(CurrentBranch, ConditionId, *NewBoardObj) || CurrentBranch.Id.IsEmpty())
-        {
-            UE_LOG(LogArcwarePlugin, Error, TEXT("Cannot find transpile data for branch condition with condition id: %s"), *ConditionId);
-            return Output;
-        }
 
         //run the transpiler
         FString ScriptModified = FString("<pre><code>") + ConditionData.Script + FString("</code></pre>");
@@ -606,7 +599,7 @@ FArcscriptTranspilerOutput UArcweaveSubsystem::TranspileConnection(
     //run the transpiler
     try
     {
-        Output = RunTranspiler(ScriptData, OriginElementId, ProjectData.CurrentVars, ProjectData.Visits, false);
+        Output = RunTranspiler(ScriptData, OriginElementId, ProjectData.CurrentVars, ProjectData.Visits, true);
         if (bStripHtmlTags)
         {
             Output.Output = RemoveHtmlTags(Output.Output);


### PR DESCRIPTION
# ABOUT
In Transpile Condition we were passing "false" to the function 

```cpp 
FArcscriptTranspilerOutput UArcweaveSubsystem::RunTranspiler(const FString& NodeCode, const FString& OriginElementId,
    const TMap<FString, FArcweaveVariable>& InitialVars, const TMap<FString, int>& Visits, bool bShouldUpdateVariables /* = true*/)
```

This was preventing labels in connections like ``` have_potion = true``` to work. This change fix them

## Changes
Transpiler logic changes:

* Removed the check for branch existence and related error logging in `TranspileCondition`, allowing the transpiler to run regardless of whether the branch data is found since this check was due to a previous logic not used anymore

* Changed the fifth parameter of the `RunTranspiler` call in `TranspileConnection` from `false` to `true`, which may alter how the transpiler processes connection scripts.