### PR TITLE
[Feature] Support multiple locales

### DIFF
--- a/Source/arcweave/Private/ArcweaveContent.cpp
+++ b/Source/arcweave/Private/ArcweaveContent.cpp
@@ -1,0 +1,30 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+// File include
+#include "ArcweaveContent.h"
+
+bool FArcweaveContent::GetTranslationForKey(FString& OutTranslation, const FString& Locale, const FString& Key) const
+{
+    if (LocalizedStringFields.Contains(Key))
+    {
+        return LocalizedStringFields[Key].GetTranslation(OutTranslation, Locale);
+    }
+
+    return false;
+}
+
+void FArcweaveContent::AddTranslationForKey(const FString& Locale, const FString& Translation, const FString& Key)
+{
+    if (LocalizedStringFields.Contains(Key))
+    {
+        FArcweaveLocalizedText& LocalizedTextRef = LocalizedStringFields[Key];
+        LocalizedTextRef.AddTranslation(Locale, Translation);
+    }
+    else
+    {
+        FArcweaveLocalizedText LocalizedText;
+        LocalizedText.AddTranslation(Locale, Translation);
+        LocalizedStringFields.Add(Key, LocalizedText);
+    }
+
+}

--- a/Source/arcweave/Private/ArcweaveContent.cpp
+++ b/Source/arcweave/Private/ArcweaveContent.cpp
@@ -28,3 +28,19 @@ void FArcweaveContent::AddTranslationForKey(const FString& Locale, const FString
     }
 
 }
+
+void FArcweaveContent::PrintContent() const
+{
+    UE_LOG(LogTemp, Log, TEXT(" ---- ArcweaveContent: LocalizedStringFields count: %d ----"), LocalizedStringFields.Num());
+    UE_LOG(LogTemp, Log, TEXT("ArcweaveContent: LocalizedStringFields count: %d"), LocalizedStringFields.Num());
+    for (const TPair<FString, FArcweaveLocalizedText>& Pair : LocalizedStringFields)
+    {
+        const FString& Key = Pair.Key;
+        const FArcweaveLocalizedText& LocalizedText = Pair.Value;
+        UE_LOG(LogTemp, Log, TEXT("  Key: %s"), *Key);
+        LocalizedText.PrintTranslations();
+    }
+
+    UE_LOG(LogTemp, Log, TEXT(" ---- ------------------------------------------------- ----"));
+
+}

--- a/Source/arcweave/Private/ArcweaveContent.cpp
+++ b/Source/arcweave/Private/ArcweaveContent.cpp
@@ -5,9 +5,11 @@
 
 bool FArcweaveContent::GetTranslationForKey(FString& OutTranslation, const FString& Locale, const FString& Key) const
 {
-    if (LocalizedStringFields.Contains(Key))
+    const FArcweaveLocalizedText* localizedText = LocalizedStringFields.Find(Key);
+
+    if (localizedText != nullptr)
     {
-        return LocalizedStringFields[Key].GetTranslation(OutTranslation, Locale);
+        return localizedText->GetTranslation(OutTranslation, Locale);
     }
 
     return false;
@@ -32,7 +34,6 @@ void FArcweaveContent::AddTranslationForKey(const FString& Locale, const FString
 void FArcweaveContent::PrintContent() const
 {
     UE_LOG(LogTemp, Log, TEXT(" ---- ArcweaveContent: LocalizedStringFields count: %d ----"), LocalizedStringFields.Num());
-    UE_LOG(LogTemp, Log, TEXT("ArcweaveContent: LocalizedStringFields count: %d"), LocalizedStringFields.Num());
     for (const TPair<FString, FArcweaveLocalizedText>& Pair : LocalizedStringFields)
     {
         const FString& Key = Pair.Key;

--- a/Source/arcweave/Private/ArcweaveContents.cpp
+++ b/Source/arcweave/Private/ArcweaveContents.cpp
@@ -5,11 +5,13 @@
 
 bool FArcweaveContents::GetContent(FArcweaveContent& OutContent, const FString& Id) const
 {
-    if (Contents.Contains(Id))
+    const FArcweaveContent* FoundContent = Contents.Find(Id);
+    if (FoundContent != nullptr)
     {
-        OutContent = Contents[Id];
+        OutContent = *FoundContent;
         return true;
     }
+
     return false;
 }
 

--- a/Source/arcweave/Private/ArcweaveContents.cpp
+++ b/Source/arcweave/Private/ArcweaveContents.cpp
@@ -3,16 +3,34 @@
 // File include
 #include "ArcweaveContents.h"
 
-FArcweaveContent FArcweaveContents::GetContent(const FString& Id) const
+bool FArcweaveContents::GetContent(FArcweaveContent& OutContent, const FString& Id) const
 {
     if (Contents.Contains(Id))
     {
-        return Contents[Id];
+        OutContent = Contents[Id];
+        return true;
     }
-    return FArcweaveContent();
+    return false;
 }
 
 void FArcweaveContents::AddContent(const FString& ContentKey, const FArcweaveContent& Content)
 {
     Contents.Add(ContentKey, Content);
+}
+
+void FArcweaveContents::PrintContents() const
+{
+    //Print contents
+    UE_LOG(LogTemp, Log, TEXT(" ---- CONTENTS ---- "));
+
+    for (const TPair<FString, FArcweaveContent>& Pair : Contents)
+    {
+        const FString& Key = Pair.Key;
+        const FArcweaveContent& LocalizedText = Pair.Value;
+        UE_LOG(LogTemp, Log, TEXT(" Key: %s"), *Key);
+        LocalizedText.PrintContent();
+    }
+
+    UE_LOG(LogTemp, Log, TEXT(" ---- ---------- ---- "));
+
 }

--- a/Source/arcweave/Private/ArcweaveContents.cpp
+++ b/Source/arcweave/Private/ArcweaveContents.cpp
@@ -1,0 +1,18 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+// File include
+#include "ArcweaveContents.h"
+
+FArcweaveContent FArcweaveContents::GetContent(const FString& Id) const
+{
+    if (Contents.Contains(Id))
+    {
+        return Contents[Id];
+    }
+    return FArcweaveContent();
+}
+
+void FArcweaveContents::AddContent(const FString& ContentKey, const FArcweaveContent& Content)
+{
+    Contents.Add(ContentKey, Content);
+}

--- a/Source/arcweave/Private/ArcweaveLocalizedText.cpp
+++ b/Source/arcweave/Private/ArcweaveLocalizedText.cpp
@@ -1,0 +1,21 @@
+#pragma once
+
+// File include
+#include "ArcweaveLocalizedText.h"
+
+void FArcweaveLocalizedText::AddTranslation(const FString& Locale, const FString& Translation)
+{
+    TextTranslations.Add(Locale, Translation);
+}
+
+bool FArcweaveLocalizedText::GetTranslation(FString& OutTranslation, const FString& Locale) const
+{
+    const FString* FoundTranslation = TextTranslations.Find(Locale);
+    if (FoundTranslation)
+    {
+        OutTranslation = *FoundTranslation;
+        return true;
+    }
+    return false;
+}
+

--- a/Source/arcweave/Private/ArcweaveLocalizedText.cpp
+++ b/Source/arcweave/Private/ArcweaveLocalizedText.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 // File include
 #include "ArcweaveLocalizedText.h"
 

--- a/Source/arcweave/Private/ArcweaveLocalizedText.cpp
+++ b/Source/arcweave/Private/ArcweaveLocalizedText.cpp
@@ -19,3 +19,14 @@ bool FArcweaveLocalizedText::GetTranslation(FString& OutTranslation, const FStri
     return false;
 }
 
+void FArcweaveLocalizedText::PrintTranslations() const
+{
+    UE_LOG(LogTemp, Log, TEXT(" ---- Translations ----"));
+    for (const auto& Pair : TextTranslations)
+    {
+        UE_LOG(LogTemp, Log, TEXT("Locale: %s, Translation: %s"), *Pair.Key, *Pair.Value);
+    }
+    UE_LOG(LogTemp, Log, TEXT(" ---- ----------- ----"));
+
+}
+

--- a/Source/arcweave/Private/ArcweaveSettings.cpp
+++ b/Source/arcweave/Private/ArcweaveSettings.cpp
@@ -12,3 +12,15 @@ void UArcweaveSettings::PostInitProperties()
 	UObject::PostInitProperties();
 	TryUpdateDefaultConfigFile(TEXT(""), false);
 }
+
+FString UArcweaveSettings::GetLocale() const
+{
+    if (bUseLocale)
+    {
+        return Locale;
+    }
+    else
+    {
+        return TEXT("en");
+    }
+}

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -55,7 +55,7 @@ void UArcweaveSubsystem::TryAddLanguageOptionToURL(FString& ApiUrl)
     }
 
     const FString DefaultLocale = ArcweaveSettings->GetLocale();
-    if (ArcweaveSettings->GetUseLocale() && !DefaultLocale.IsEmpty())
+    if (!DefaultLocale.IsEmpty())
     {
         // Ensure the variable can be safely inserted in a URL by encoding it
         FString EscapedDefaultLocale = FGenericPlatformHttp::UrlEncode(DefaultLocale);

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -55,7 +55,7 @@ void UArcweaveSubsystem::TryAddLanguageOptionToURL(FString& ApiUrl)
     }
 
     const FString DefaultLocale = ArcweaveSettings->GetLocale();
-    if (!DefaultLocale.IsEmpty())
+    if (ArcweaveSettings->GetUseLocale() && !DefaultLocale.IsEmpty())
     {
         // Ensure the variable can be safely inserted in a URL by encoding it
         FString EscapedDefaultLocale = FGenericPlatformHttp::UrlEncode(DefaultLocale);

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1669,8 +1669,6 @@ FArcweaveContents UArcweaveSubsystem::ParseAllContents(const TSharedPtr<FJsonObj
         }
     }
 
-    ParsedContents.PrintContents();
-
     return ParsedContents;
 }
 

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -289,6 +289,35 @@ void UArcweaveSubsystem::PrintBranchData(const FArcweaveBranchData& InData)
 
 }
 
+FString UArcweaveSubsystem::GetFallbackLanguageForLocale(const FString& Locale) const
+{
+    if (ProjectData.Locales.Num() == 0)
+    {
+        UE_LOG(LogArcwarePlugin, Error, TEXT("No locales found in project data, cannot get fallback language for locale: %s"), *Locale);
+        return FString();
+    }
+
+    for (const FArcweaveLocaleData& LocaleData : ProjectData.Locales)
+    {
+        if (LocaleData.Iso == Locale)
+        {
+            if (LocaleData.HasFallbackLanguage())
+            {
+                return LocaleData.Base;
+            }
+            else
+            {
+                UE_LOG(LogArcwarePlugin, Warning, TEXT("Locale %s does not have a fallback language defined or is the default language"), *Locale);
+                return FString();
+            }
+        }
+    }
+
+    UE_LOG(LogArcwarePlugin, Error, TEXT("Cannot get fallback language for locale: %s in the current locales"), *Locale);
+
+    return FString();
+}
+
 FArcscriptTranspilerOutput UArcweaveSubsystem::TranspileCondition(const FString& ConditionId, const FString& OriginElementId, bool& Success)
 {
     UE_LOG(LogArcwarePlugin, Log, TEXT("----- TranspileCondition for id: %s -----"), *ConditionId);
@@ -872,6 +901,11 @@ TArray<FArcweaveConnectionsData> UArcweaveSubsystem::ParseConnections(const FStr
     // Parse "connections" as an array of connection data structs
     TArray<FArcweaveConnectionsData> Connections;
     TArray<FString> ConnectionsArrayStrings;
+
+    FString DesiredLocale = FString("");
+    bool bFallbackToDefaultLanguage = false;
+    GetLanguageSettings(DesiredLocale, bFallbackToDefaultLanguage);
+
     if (ParentValueObject->TryGetStringArrayField(FieldName, ConnectionsArrayStrings))
     {
         for (const FString& ConnectionId : ConnectionsArrayStrings)
@@ -892,12 +926,20 @@ TArray<FArcweaveConnectionsData> UArcweaveSubsystem::ParseConnections(const FStr
                         {
                             FString RawLabel = FString("");
 
-                            if (ConObject->TryGetStringField(TEXT("label"), RawLabel))
+                            if (HasLocales())
                             {
+                                RawLabel = GetTranslatedContent(ConnectionId, TEXT("label"), DesiredLocale, bFallbackToDefaultLanguage);
+                            }
+                            else 
+                            {
+                                ConObject->TryGetStringField(TEXT("label"), RawLabel);
+                            }
 
+                            if (!RawLabel.IsEmpty())
+                            {
                                 if (ContainsCodePattern(RawLabel))
                                 {
-                                    // Keep the raw code so it can be analyzed later
+                                    // Keep the raw code so it can be analysed later
                                     Connection.Label = RawLabel;
                                 }
                                 else
@@ -906,6 +948,12 @@ TArray<FArcweaveConnectionsData> UArcweaveSubsystem::ParseConnections(const FStr
                                     Connection.Label = RemoveHtmlTags(RawLabel);
                                 }
                             }
+                            else
+                            {
+                                UE_LOG(LogArcwarePlugin, Warning, TEXT("No label text was provided for connection with ID: %s"), *ConnectionId);
+                            }
+
+
                             ConObject->TryGetStringField(TEXT("type"), Connection.Type);
                             ConObject->TryGetStringField(TEXT("theme"), Connection.Theme);
                             ConObject->TryGetStringField(TEXT("sourceid"), Connection.Sourceid);
@@ -1072,6 +1120,11 @@ FArcweaveElementData UArcweaveSubsystem::ExtractElementData(
 {
     FArcweaveElementData Element;
     const TSharedPtr<FJsonObject>* ElementsObject;
+
+    FString DesiredLocale = FString("");
+    bool bFallbackToDefaultLanguage = false;
+    GetLanguageSettings(DesiredLocale, bFallbackToDefaultLanguage);
+
     if (MainJsonObject->TryGetObjectField(TEXT("elements"), ElementsObject))
     {
         for (const auto& ElementPair : ElementsObject->Get()->Values)
@@ -1087,11 +1140,21 @@ FArcweaveElementData UArcweaveSubsystem::ExtractElementData(
 
                     //get the values from the json object
                     ElementValueObject->TryGetStringField(TEXT("theme"), Element.Theme);
+                    
                     FString DirtyTitle = FString("");
-                    ElementValueObject->TryGetStringField(TEXT("title"), DirtyTitle);
+
+                    if (HasLocales()) 
+                    {
+                        DirtyTitle = GetTranslatedContent(Element.Id, TEXT("title"), DesiredLocale, bFallbackToDefaultLanguage);
+                        Element.Content = GetTranslatedContent(Element.Id, TEXT("content"), DesiredLocale, bFallbackToDefaultLanguage);
+                    }
+                    else
+                    {
+                        ElementValueObject->TryGetStringField(TEXT("title"), DirtyTitle);
+                        ElementValueObject->TryGetStringField(TEXT("content"), Element.Content);
+                    }
+
                     Element.Title = RemoveHtmlTags(DirtyTitle);
-                    FString DirtyContent = FString("");
-                    ElementValueObject->TryGetStringField(TEXT("content"), Element.Content);
                     //FArcscriptTranspilerOutput Output = RunTranspiler(DirtyContent, Element.Id, ProjectData.InitialVars, BoardObj.Visits);
                     Element.Outputs = ParseConnections(FString("outputs"), MainJsonObject, ElementValueObject, BoardObjRef);
                     Element.Components = ParseComponents(MainJsonObject, ElementValueObject);
@@ -1210,15 +1273,9 @@ TArray<FArcweaveComponentData> UArcweaveSubsystem::ParseComponents(const TShared
     TArray<FArcweaveComponentData> Components;
     TArray<FString> ComponentsStringArray;
  
-    const UArcweaveSettings* ArcweaveSettings = GetMutableDefault<UArcweaveSettings>();
     FString DesiredLocale = FString("");
     bool bFallbackToDefaultLanguage = false;
-    if (IsValid(ArcweaveSettings))
-    {
-        //TODO:: SET IT USING the default locale
-        DesiredLocale = !ArcweaveSettings->GetLocale().IsEmpty() ? ArcweaveSettings->GetLocale() : TEXT("en");
-        bFallbackToDefaultLanguage = ArcweaveSettings->GetFallbackToDefaultLocale();
-    }
+    GetLanguageSettings(DesiredLocale, bFallbackToDefaultLanguage);
 
     if (ElementValueObject->TryGetStringArrayField(TEXT("components"), ComponentsStringArray))
     {
@@ -1238,28 +1295,10 @@ TArray<FArcweaveComponentData> UArcweaveSubsystem::ParseComponents(const TShared
 
                         if (ComponentValueObject.IsValid())
                         {
-                            // Extract the "name" and "root"
+                            // If it has locale the content has been already saved in contents, so we just need to retrieve it
                             if (HasLocales())
                             {
-                                FArcweaveLocalizedText LocalizedText;
-                                // In ParseComponents, replace the section where the component name is set with the following:
-
-                                ElComponent.NameLocalizedText = ParseElementTranslations(ComponentValueObject, TEXT("name"));
-                                FString BaseTranslation;
-                                if (ElComponent.NameLocalizedText.GetTranslation(BaseTranslation, DesiredLocale))
-                                {
-                                    ElComponent.Name = BaseTranslation;
-                                }
-                                else if (bFallbackToDefaultLanguage)
-                                {
-                                    // TODO pick the default language from ProjectData.Locales in the respective base element
-                                    // Fallback to "en" if base locale translation not found
-                                    if (ElComponent.NameLocalizedText.GetTranslation(BaseTranslation, TEXT("en")))
-                                    {
-                                        ElComponent.Name = BaseTranslation;
-                                    }
-                                }
-
+                                ElComponent.Name = GetTranslatedContent(ElComponent.Id, TEXT("name"), DesiredLocale, bFallbackToDefaultLanguage);
                             }
                             else
                             {
@@ -1289,16 +1328,28 @@ TArray<FArcweaveComponentData> UArcweaveSubsystem::ParseAllComponents(const TSha
     const TSharedPtr<FJsonObject>* CompObject;
     if (MainJsonObject->TryGetObjectField(TEXT("components"), CompObject))
     {
+        // Get settings 
+        FString DesiredLocale = FString("");
+        bool bFallbackToDefaultLanguage = false;
+        GetLanguageSettings(DesiredLocale, bFallbackToDefaultLanguage);
+
         for (const auto& CompPair : CompObject->Get()->Values)
         {
             FArcweaveComponentData ElComponent;
             ElComponent.Id = CompPair.Key;
             const TSharedPtr<FJsonObject> ComponentValueObject = CompPair.Value->AsObject();
 
+            // Extract the "name" and "root"
             if (ComponentValueObject.IsValid())
             {
-                // Extract the "name" and "root"
-                ComponentValueObject->TryGetStringField(TEXT("name"), ElComponent.Name);
+                if (HasLocales())
+                {
+                    ElComponent.Name = GetTranslatedContent(CompPair.Key, TEXT("name"), DesiredLocale, bFallbackToDefaultLanguage);
+                }
+                else
+                {
+                    ComponentValueObject->TryGetStringField(TEXT("name"), ElComponent.Name);
+                }
                 ComponentValueObject->TryGetBoolField(TEXT("root"), ElComponent.Root);
                 ComponentValueObject->TryGetStringArrayField(TEXT("children"), ElComponent.Children);
                 ElComponent.Assets = ParseComponentAsset(ComponentValueObject);
@@ -1408,30 +1459,48 @@ TArray<FArcweaveLocaleData> UArcweaveSubsystem::ParseProjectLocales(const TShare
     return Locales;
 }
 
-FArcweaveLocalizedText UArcweaveSubsystem::ParseElementTranslations(const TSharedPtr<FJsonObject> ComponentValueObject, const FStringView& FieldName)
+FString UArcweaveSubsystem::GetTranslatedContent(const FString& ContentKey, const FString& FieldName, const FString& CurrentLocale, bool ShouldFallback = true) const
 {
-    FArcweaveLocalizedText Localizations;
-    const TSharedPtr<FJsonObject>* NameLocalizedObject;
-    if (ComponentValueObject->TryGetObjectField(FieldName, NameLocalizedObject))
-    {
-        for (const auto& LocalePair : NameLocalizedObject->Get()->Values)
-        {
-            FString Locale = LocalePair.Key;
-            const TSharedPtr<FJsonObject> LocaleTextObject = LocalePair.Value->AsObject();
-            FString Translation;
-            if (LocaleTextObject.IsValid() && LocaleTextObject->TryGetStringField(TEXT("text"), Translation))
-            {
+    FString OutTranslation;
 
-                Localizations.AddTranslation(Locale, Translation);
-            }
+    FArcweaveContent Content;
+    if (!ProjectData.Contents.GetContent(Content, ContentKey))
+    {
+        UE_LOG(LogArcwarePlugin, Warning, TEXT("ContentKey '%s' not found in Contents."), *ContentKey);
+        return FString();
+    }
+
+    if (Content.GetTranslationForKey(OutTranslation, CurrentLocale, FieldName))
+    {
+        return OutTranslation;
+    }
+
+    // If fallback is allowed, try to find a fallback locale
+    if (ShouldFallback)
+    {
+        FString FallbackLocale = GetFallbackLanguageForLocale(CurrentLocale);
+        if (!FallbackLocale.IsEmpty() && Content.GetTranslationForKey(OutTranslation, FallbackLocale, FieldName))
+        {
+            return OutTranslation;
         }
     }
-    else
-    {
-        UE_LOG(LogArcwarePlugin, Error, TEXT("Failed to get localized object field '%s'."), *FString(FieldName));
-    }
 
-    return Localizations;
+    // If nothing found, return empty string
+    UE_LOG(LogArcwarePlugin, Warning, TEXT("No translation found for ContentKey '%s', FieldName '%s', Locale '%s'."), *ContentKey, *FieldName, *CurrentLocale);
+    return FString();
+}
+
+void UArcweaveSubsystem::GetLanguageSettings(FString& OutDesiredLocale, bool& OutFallbackToDefaultLanguage)
+{
+    const UArcweaveSettings* ArcweaveSettings = GetMutableDefault<UArcweaveSettings>();
+
+    OutDesiredLocale = TEXT("");
+    OutFallbackToDefaultLanguage = false;
+    if (IsValid(ArcweaveSettings))
+    {
+        OutDesiredLocale = !ArcweaveSettings->GetLocale().IsEmpty() ? ArcweaveSettings->GetLocale() : TEXT("en");
+        OutFallbackToDefaultLanguage = ArcweaveSettings->GetFallbackToDefaultLocale();
+    }
 }
 
 void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
@@ -1527,7 +1596,7 @@ FArcweaveContents UArcweaveSubsystem::ParseAllContents(const TSharedPtr<FJsonObj
                             FString Translation;
                             if (LocaleData->TryGetStringField(TEXT("text"), Translation))
                             {
-                                ArcweaveContent.AddTranslationForKey(FieldKey, Translation, FieldKey);
+                                ArcweaveContent.AddTranslationForKey(Locale, Translation, FieldKey);
                             }
                         }
                     }
@@ -1539,6 +1608,8 @@ FArcweaveContents UArcweaveSubsystem::ParseAllContents(const TSharedPtr<FJsonObj
             ParsedContents.AddContent(ContentId, ArcweaveContent);
         }
     }
+
+    ParsedContents.PrintContents();
 
     return ParsedContents;
 }

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -561,7 +561,7 @@ FString UArcweaveSubsystem::TranspileConnectionLabel(const FArcweaveConnectionsD
 
 bool UArcweaveSubsystem::HasLocales() const
 {
-    return ProjectData.Locales.Num() > 0;
+    return ProjectData.Locales.Num() > 1;
 }
 
 FArcweaveElementData UArcweaveSubsystem::TranspileObject(FString ObjectId, bool& Success, bool bStripHtmlTags /*true*/)
@@ -1542,7 +1542,7 @@ void UArcweaveSubsystem::UpdateContentsWithLocale(const FString& DesiredLocale)
     {
         for (FArcweaveElementData& element : board.Elements)
         {
-            element.Title = GetTranslatedContent(element.Id, TEXT("title"), DesiredLocale, bFallbackToDefaultLanguage);
+            element.Title = RemoveHtmlTags(GetTranslatedContent(element.Id, TEXT("title"), DesiredLocale, bFallbackToDefaultLanguage));
             element.Content = GetTranslatedContent(element.Id, TEXT("content"), DesiredLocale, bFallbackToDefaultLanguage);
 
             for (auto& component : element.Components)
@@ -1625,7 +1625,8 @@ FArcweaveContents UArcweaveSubsystem::ParseAllContents(const TSharedPtr<FJsonObj
 
             if (!ContentData.IsValid())
             {
-                return ParsedContents;
+                UE_LOG(LogArcwarePlugin, Warning, TEXT("UArcweaveSubsystem::ParseAllContents: Invalid ContentData for ContentId '%s'. Skipping this entry."), *ContentId);
+                continue;
             }
 
             FArcweaveContent ArcweaveContent;
@@ -1644,8 +1645,6 @@ FArcweaveContents UArcweaveSubsystem::ParseAllContents(const TSharedPtr<FJsonObj
 
                 if (LocalizedObject.IsValid())
                 {
-                    FArcweaveLocalizedText LocalizedText;
-
                     // Parse translations for each locale
                     for (const auto& LocalePair : LocalizedObject->Values)
                     {

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1503,6 +1503,52 @@ void UArcweaveSubsystem::GetLanguageSettings(FString& OutDesiredLocale, bool& Ou
     }
 }
 
+void UArcweaveSubsystem::UpdateContentsWithLocale(const FString& DesiredLocale)
+{
+
+    if (!HasLocales())
+    {
+        UE_LOG(LogArcwarePlugin, Warning, TEXT("No other locale is available - can't update the locale to %s"), *DesiredLocale);
+        return;
+    }
+
+    UArcweaveSettings* ArcweaveSettings = GetMutableDefault<UArcweaveSettings>();
+    bool bFallbackToDefaultLanguage = false;
+    if (!IsValid(ArcweaveSettings))
+    {
+        UE_LOG(LogArcwarePlugin, Error, TEXT("Unable to change settings locale to %s - settings not available"), *DesiredLocale);
+        return;
+    }
+
+    ArcweaveSettings->SetLocale(DesiredLocale);
+    bFallbackToDefaultLanguage = ArcweaveSettings->GetFallbackToDefaultLocale();
+
+    for (auto& board : ProjectData.Boards)
+    {
+        for (FArcweaveElementData& element : board.Elements)
+        {
+            element.Title = GetTranslatedContent(element.Id, TEXT("title"), DesiredLocale, bFallbackToDefaultLanguage);
+            element.Content = GetTranslatedContent(element.Id, TEXT("content"), DesiredLocale, bFallbackToDefaultLanguage);
+
+            for (auto& component : element.Components)
+            {
+                component.Name = GetTranslatedContent(component.Id, TEXT("name"), DesiredLocale, bFallbackToDefaultLanguage);
+            }
+        }
+
+        for (FArcweaveConnectionsData& connection : board.Connections)
+        {
+            connection.Label = GetTranslatedContent(connection.Id, TEXT("label"), DesiredLocale, bFallbackToDefaultLanguage);
+        }
+
+    }
+
+    if (OnArcweaveLanguageChanged.IsBound())
+    {
+        OnArcweaveLanguageChanged.Broadcast(DesiredLocale);
+    }
+}
+
 void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
 {
     TSharedPtr<FJsonObject> RootObject;

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -961,11 +961,6 @@ TArray<FArcweaveConnectionsData> UArcweaveSubsystem::ParseConnections(const FStr
                                     Connection.Label = RemoveHtmlTags(RawLabel);
                                 }
                             }
-                            else
-                            {
-                                UE_LOG(LogArcwarePlugin, Warning, TEXT("No label text was provided for connection with ID: %s"), *ConnectionId);
-                            }
-
 
                             ConObject->TryGetStringField(TEXT("type"), Connection.Type);
                             ConObject->TryGetStringField(TEXT("theme"), Connection.Theme);
@@ -1486,10 +1481,9 @@ TArray<FArcweaveLocaleData> UArcweaveSubsystem::ParseProjectLocales(const TShare
     return Locales;
 }
 
-FString UArcweaveSubsystem::GetTranslatedContent(const FString& ContentKey, const FString& FieldName, const FString& CurrentLocale, bool ShouldFallback = true) const
+FString UArcweaveSubsystem::GetTranslatedContent(const FString& ContentKey, const FString& FieldName, const FString& CurrentLocale, bool ShouldFallback) const
 {
     FString OutTranslation;
-
     FArcweaveContent Content;
     if (!ProjectData.Contents.GetContent(Content, ContentKey))
     {
@@ -1497,24 +1491,69 @@ FString UArcweaveSubsystem::GetTranslatedContent(const FString& ContentKey, cons
         return FString();
     }
 
+    // Try direct translation first
     if (Content.GetTranslationForKey(OutTranslation, CurrentLocale, FieldName))
     {
         return OutTranslation;
     }
 
-    // If fallback is allowed, try to find a fallback locale
     if (ShouldFallback)
     {
-        FString FallbackLocale = GetFallbackLanguageForLocale(CurrentLocale);
-        if (!FallbackLocale.IsEmpty() && Content.GetTranslationForKey(OutTranslation, FallbackLocale, FieldName))
+        return TryToFindFallbackTranslation(Content, FieldName, CurrentLocale);
+    }
+
+    UE_LOG(LogArcwarePlugin, Warning, TEXT("No translation found for ContentKey '%s', FieldName '%s', Locale '%s'."), *ContentKey, *FieldName, *CurrentLocale);
+    return FString();
+}
+
+FString UArcweaveSubsystem::TryToFindFallbackTranslation(const FArcweaveContent& Content, const FString& FieldName, const FString& CurrentLocale) const
+{
+    FString OutTranslation;
+    TSet<FString> VisitedLocales;
+
+    FString NextLocale = CurrentLocale;
+    while (true)
+    {
+        VisitedLocales.Add(NextLocale);
+        FString FallbackLocale = GetFallbackLanguageForLocale(NextLocale);
+        if (FallbackLocale.IsEmpty())
+        {
+            UE_LOG(LogArcwarePlugin, Warning, TEXT("No fallback translation found for FieldName '%s', Locale '%s'."), *FieldName, *CurrentLocale);
+            break;
+        }
+
+        if (VisitedLocales.Contains(FallbackLocale))
+        {
+            UE_LOG(
+                LogArcwarePlugin,
+                Warning,
+                TEXT("Loop of fallback locales identified while trying to find fallback locale for '%s' while visiting locale '%s' (e.g. fr->it, it->dt, dt->it)."),
+                *CurrentLocale,
+                *NextLocale
+            );
+            break;
+        }
+
+        if (Content.GetTranslationForKey(OutTranslation, FallbackLocale, FieldName))
         {
             return OutTranslation;
         }
+        NextLocale = FallbackLocale;
     }
 
-    // If nothing found, return empty string
-    UE_LOG(LogArcwarePlugin, Warning, TEXT("No translation found for ContentKey '%s', FieldName '%s', Locale '%s'."), *ContentKey, *FieldName, *CurrentLocale);
-    return FString();
+    // As a last resort, try any available translation for the field
+    for (const FArcweaveLocaleData& LocaleData : ProjectData.Locales)
+    {
+        if (!VisitedLocales.Contains(LocaleData.Iso))
+        {
+            if (Content.GetTranslationForKey(OutTranslation, LocaleData.Iso, FieldName))
+            {
+                return OutTranslation;
+            }
+        }
+    }
+
+    return OutTranslation;
 }
 
 void UArcweaveSubsystem::GetLanguageSettings(FString& OutDesiredLocale, bool& OutFallbackToDefaultLanguage)
@@ -1574,6 +1613,11 @@ void UArcweaveSubsystem::UpdateContentsWithLocale(const FString& DesiredLocale)
             connection.Label = GetTranslatedContent(connection.Id, TEXT("label"), DesiredLocale, bFallbackToDefaultLanguage);
         }
 
+    }
+
+    for (FArcweaveComponentData& component : ProjectData.Components)
+    {
+        component.Name = GetTranslatedContent(component.Id, TEXT("name"), DesiredLocale, bFallbackToDefaultLanguage);
     }
 
     if (OnArcweaveLanguageChanged.IsBound())

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1408,32 +1408,6 @@ TArray<FArcweaveLocaleData> UArcweaveSubsystem::ParseProjectLocales(const TShare
     return Locales;
 }
 
-FArcweaveLocalizedText UArcweaveSubsystem::ParseElementTranslations(const TSharedPtr<FJsonObject> ComponentValueObject, const FStringView& FieldName)
-{
-    FArcweaveLocalizedText Localizations;
-    const TSharedPtr<FJsonObject>* NameLocalizedObject;
-    if (ComponentValueObject->TryGetObjectField(FieldName, NameLocalizedObject))
-    {
-        for (const auto& LocalePair : NameLocalizedObject->Get()->Values)
-        {
-            FString Locale = LocalePair.Key;
-            const TSharedPtr<FJsonObject> LocaleTextObject = LocalePair.Value->AsObject();
-            FString Translation;
-            if (LocaleTextObject.IsValid() && LocaleTextObject->TryGetStringField(TEXT("text"), Translation))
-            {
-
-                Localizations.AddTranslation(Locale, Translation);
-            }
-        }
-    }
-    else
-    {
-        UE_LOG(LogArcwarePlugin, Error, TEXT("Failed to get localized object field '%s'."), *FString(FieldName));
-    }
-
-    return Localizations;
-}
-
 void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
 {
     TSharedPtr<FJsonObject> RootObject;

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -530,6 +530,11 @@ FString UArcweaveSubsystem::TranspileConnectionLabel(const FArcweaveConnectionsD
     return Connection.Label;
 }
 
+bool UArcweaveSubsystem::HasLocales() const
+{
+    return ProjectData.Locales.Num() > 0;
+}
+
 FArcweaveElementData UArcweaveSubsystem::TranspileObject(FString ObjectId, bool& Success, bool bStripHtmlTags /*true*/)
 {
     Success = false;

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1549,6 +1549,11 @@ void UArcweaveSubsystem::UpdateContentsWithLocale(const FString& DesiredLocale)
             {
                 component.Name = GetTranslatedContent(component.Id, TEXT("name"), DesiredLocale, bFallbackToDefaultLanguage);
             }
+
+            for (auto& output : element.Outputs)
+            {
+                output.Label = GetTranslatedContent(output.Id, TEXT("label"), DesiredLocale, bFallbackToDefaultLanguage);
+            }
         }
 
         for (FArcweaveConnectionsData& connection : board.Connections)

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1340,6 +1340,37 @@ FArcweaveCoverData UArcweaveSubsystem::ParseCoverData(const TSharedPtr<FJsonObje
     return CoverData;
 }
 
+TArray<FArcweaveLocaleData> UArcweaveSubsystem::ParseLocales(const TSharedPtr<FJsonObject>& MainJsonObject)
+{
+    TArray<FArcweaveLocaleData> Locales;
+    const TArray<TSharedPtr<FJsonValue>>* LocalesArray;
+
+    if (MainJsonObject->TryGetArrayField(TEXT("locales"), LocalesArray))
+    {
+        for (const TSharedPtr<FJsonValue>& LocaleValue : *LocalesArray)
+        {
+            const TSharedPtr<FJsonObject>* LocaleObject;
+            if (LocaleValue->TryGetObject(LocaleObject))
+            {
+                FArcweaveLocaleData LocaleData;
+                (*LocaleObject)->TryGetStringField(TEXT("iso"), LocaleData.Iso);
+                (*LocaleObject)->TryGetStringField(TEXT("name"), LocaleData.Name);
+                // "base" can be null, so check if it exists and is a string
+                if ((*LocaleObject)->HasField(TEXT("base")))
+                {
+                    (*LocaleObject)->TryGetStringField(TEXT("base"), LocaleData.Base);
+                }
+                else
+                {
+                    LocaleData.Base = FString("");
+                }
+                Locales.Add(LocaleData);
+            }
+        }
+    }
+    return Locales;
+}
+
 void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
 {
     TSharedPtr<FJsonObject> RootObject;
@@ -1372,6 +1403,7 @@ void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
         ProjectData.Boards = ParseBoard(RootObject);
         ProjectData.CurrentVars = ParseVariables(RootObject);
         ProjectData.Visits = InitVisits(RootObject);
+        ProjectData.Locales = ParseLocales(RootObject);
         OnArcweaveResponseReceived.Broadcast(ProjectData);
         //LogStructFieldsRecursive(&ProjectData, FArcweaveProjectData::StaticStruct(),0);
     }

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -355,19 +355,32 @@ FArcscriptTranspilerOutput UArcweaveSubsystem::TranspileCondition(const FString&
     return Output;
 }
 
-bool UArcweaveSubsystem::GetBoardForObject(FString ObjectId, FArcweaveElementData& OutElement, FArcweaveBoardData*& OutBoardObj)
+bool UArcweaveSubsystem::GetBoardForObject(FString ElementId, FArcweaveElementData& OutElement, FArcweaveBoardData*& OutBoardObj)
 {
     for (auto& Board : ProjectData.Boards)
     {
         for (auto& ElementObj : Board.Elements)
         {
-            if (ElementObj.Id == ObjectId)
+            if (ElementObj.Id == ElementId)
             {
                 OutBoardObj = &Board;
                 OutElement = ElementObj;
                 return true;
             }
         }
+    }
+    return false;
+}
+
+bool UArcweaveSubsystem::GetBoard(FArcweaveBoardData& OutBoardObj, const FString& BoardId)
+{
+    for (auto& Board : ProjectData.Boards)
+    {
+            if (Board.BoardId == BoardId)
+            {
+                OutBoardObj = Board;
+                return true;
+            }
     }
     return false;
 }

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1408,6 +1408,32 @@ TArray<FArcweaveLocaleData> UArcweaveSubsystem::ParseProjectLocales(const TShare
     return Locales;
 }
 
+FArcweaveLocalizedText UArcweaveSubsystem::ParseElementTranslations(const TSharedPtr<FJsonObject> ComponentValueObject, const FStringView& FieldName)
+{
+    FArcweaveLocalizedText Localizations;
+    const TSharedPtr<FJsonObject>* NameLocalizedObject;
+    if (ComponentValueObject->TryGetObjectField(FieldName, NameLocalizedObject))
+    {
+        for (const auto& LocalePair : NameLocalizedObject->Get()->Values)
+        {
+            FString Locale = LocalePair.Key;
+            const TSharedPtr<FJsonObject> LocaleTextObject = LocalePair.Value->AsObject();
+            FString Translation;
+            if (LocaleTextObject.IsValid() && LocaleTextObject->TryGetStringField(TEXT("text"), Translation))
+            {
+
+                Localizations.AddTranslation(Locale, Translation);
+            }
+        }
+    }
+    else
+    {
+        UE_LOG(LogArcwarePlugin, Error, TEXT("Failed to get localized object field '%s'."), *FString(FieldName));
+    }
+
+    return Localizations;
+}
+
 void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
 {
     TSharedPtr<FJsonObject> RootObject;

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1535,6 +1535,7 @@ void UArcweaveSubsystem::UpdateContentsWithLocale(const FString& DesiredLocale)
     }
 
     ArcweaveSettings->SetLocale(DesiredLocale);
+    ArcweaveSettings->SetUseLocale(true);
     bFallbackToDefaultLanguage = ArcweaveSettings->GetFallbackToDefaultLocale();
 
     for (auto& board : ProjectData.Boards)

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1209,6 +1209,17 @@ TArray<FArcweaveComponentData> UArcweaveSubsystem::ParseComponents(const TShared
     // Parse "components" as an array of component data structs
     TArray<FArcweaveComponentData> Components;
     TArray<FString> ComponentsStringArray;
+ 
+    const UArcweaveSettings* ArcweaveSettings = GetMutableDefault<UArcweaveSettings>();
+    FString DesiredLocale = FString("");
+    bool bFallbackToDefaultLanguage = false;
+    if (IsValid(ArcweaveSettings))
+    {
+        //TODO:: SET IT USING the default locale
+        DesiredLocale = !ArcweaveSettings->GetLocale().IsEmpty() ? ArcweaveSettings->GetLocale() : TEXT("en");
+        bFallbackToDefaultLanguage = ArcweaveSettings->GetFallbackToDefaultLocale();
+    }
+
     if (ElementValueObject->TryGetStringArrayField(TEXT("components"), ComponentsStringArray))
     {
         for (const auto& ComponentId : ComponentsStringArray)
@@ -1228,7 +1239,33 @@ TArray<FArcweaveComponentData> UArcweaveSubsystem::ParseComponents(const TShared
                         if (ComponentValueObject.IsValid())
                         {
                             // Extract the "name" and "root"
-                            ComponentValueObject->TryGetStringField(TEXT("name"), ElComponent.Name);
+                            if (HasLocales())
+                            {
+                                FArcweaveLocalizedText LocalizedText;
+                                // In ParseComponents, replace the section where the component name is set with the following:
+
+                                ElComponent.NameLocalizedText = ParseElementTranslations(ComponentValueObject, TEXT("name"));
+                                FString BaseTranslation;
+                                if (ElComponent.NameLocalizedText.GetTranslation(BaseTranslation, DesiredLocale))
+                                {
+                                    ElComponent.Name = BaseTranslation;
+                                }
+                                else if (bFallbackToDefaultLanguage)
+                                {
+                                    // TODO pick the default language from ProjectData.Locales in the respective base element
+                                    // Fallback to "en" if base locale translation not found
+                                    if (ElComponent.NameLocalizedText.GetTranslation(BaseTranslation, TEXT("en")))
+                                    {
+                                        ElComponent.Name = BaseTranslation;
+                                    }
+                                }
+
+                            }
+                            else
+                            {
+                                ComponentValueObject->TryGetStringField(TEXT("name"), ElComponent.Name);
+                            }
+
                             ComponentValueObject->TryGetBoolField(TEXT("root"), ElComponent.Root);
                             ComponentValueObject->TryGetStringArrayField(TEXT("children"), ElComponent.Children);
                             ElComponent.Assets = ParseComponentAsset(ComponentValueObject);
@@ -1340,7 +1377,7 @@ FArcweaveCoverData UArcweaveSubsystem::ParseCoverData(const TSharedPtr<FJsonObje
     return CoverData;
 }
 
-TArray<FArcweaveLocaleData> UArcweaveSubsystem::ParseLocales(const TSharedPtr<FJsonObject>& MainJsonObject)
+TArray<FArcweaveLocaleData> UArcweaveSubsystem::ParseProjectLocales(const TSharedPtr<FJsonObject>& MainJsonObject)
 {
     TArray<FArcweaveLocaleData> Locales;
     const TArray<TSharedPtr<FJsonValue>>* LocalesArray;
@@ -1371,6 +1408,32 @@ TArray<FArcweaveLocaleData> UArcweaveSubsystem::ParseLocales(const TSharedPtr<FJ
     return Locales;
 }
 
+FArcweaveLocalizedText UArcweaveSubsystem::ParseElementTranslations(const TSharedPtr<FJsonObject> ComponentValueObject, const FStringView& FieldName)
+{
+    FArcweaveLocalizedText Localizations;
+    const TSharedPtr<FJsonObject>* NameLocalizedObject;
+    if (ComponentValueObject->TryGetObjectField(FieldName, NameLocalizedObject))
+    {
+        for (const auto& LocalePair : NameLocalizedObject->Get()->Values)
+        {
+            FString Locale = LocalePair.Key;
+            const TSharedPtr<FJsonObject> LocaleTextObject = LocalePair.Value->AsObject();
+            FString Translation;
+            if (LocaleTextObject.IsValid() && LocaleTextObject->TryGetStringField(TEXT("text"), Translation))
+            {
+
+                Localizations.AddTranslation(Locale, Translation);
+            }
+        }
+    }
+    else
+    {
+        UE_LOG(LogArcwarePlugin, Error, TEXT("Failed to get localized object field '%s'."), *FString(FieldName));
+    }
+
+    return Localizations;
+}
+
 void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
 {
     TSharedPtr<FJsonObject> RootObject;
@@ -1396,14 +1459,16 @@ void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
     // Extract project name and cover data     
     if (RootObject->TryGetStringField(TEXT("name"), ProjectData.Name))
     {
+        // Locales are used later so they need to be on top
+        ProjectData.Locales = ParseProjectLocales(RootObject);
         ProjectData.Cover = ParseCoverData(RootObject);
+        ProjectData.CurrentVars = ParseVariables(RootObject);
         ProjectData.Components = ParseAllComponents(RootObject);
         ProjectData.Conditions = ParseAllConditions(RootObject);
         ProjectData.Connections = ParseAllConnections(RootObject);
         ProjectData.Boards = ParseBoard(RootObject);
         ProjectData.CurrentVars = ParseVariables(RootObject);
         ProjectData.Visits = InitVisits(RootObject);
-        ProjectData.Locales = ParseLocales(RootObject);
         OnArcweaveResponseReceived.Broadcast(ProjectData);
         //LogStructFieldsRecursive(&ProjectData, FArcweaveProjectData::StaticStruct(),0);
     }

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1387,10 +1387,15 @@ TArray<FArcweaveConditionData> UArcweaveSubsystem::ParseAllConditions(const TSha
 
 TArray<FArcweaveConnectionsData> UArcweaveSubsystem::ParseAllConnections(const TSharedPtr<FJsonObject>& MainJsonObject)
 {
+    FString DesiredLocale = FString("");
+    bool bFallbackToDefaultLanguage = false;
+    GetLanguageSettings(DesiredLocale, bFallbackToDefaultLanguage);
+
     TArray<FArcweaveConnectionsData> Connections;
     const TSharedPtr<FJsonObject>* CondObject;
     if (MainJsonObject->TryGetObjectField(TEXT("connections"), CondObject))
     {
+        
         for (const auto& CompPair : CondObject->Get()->Values)
         {
             FArcweaveConnectionsData ConditionData;
@@ -1399,8 +1404,17 @@ TArray<FArcweaveConnectionsData> UArcweaveSubsystem::ParseAllConnections(const T
 
             if (ComponentValueObject.IsValid())
             {
+                
+                if (HasLocales())
+                {
+                    ConditionData.Label = GetTranslatedContent(ConditionData.Id, TEXT("label"), DesiredLocale, bFallbackToDefaultLanguage);
+                }
+                else 
+                {
+                    ComponentValueObject->TryGetStringField(TEXT("label"), ConditionData.Label);
+                }
+
                 ComponentValueObject->TryGetStringField(TEXT("type"), ConditionData.Type);
-                ComponentValueObject->TryGetStringField(TEXT("label"), ConditionData.Label);
                 ComponentValueObject->TryGetStringField(TEXT("theme"), ConditionData.Theme);
                 ComponentValueObject->TryGetStringField(TEXT("sourceid"), ConditionData.Sourceid);
                 ComponentValueObject->TryGetStringField(TEXT("targetid"), ConditionData.Targetid);

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -1461,6 +1461,7 @@ void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
     {
         // Locales are used later so they need to be on top
         ProjectData.Locales = ParseProjectLocales(RootObject);
+        ProjectData.Contents = ParseAllContents(RootObject);
         ProjectData.Cover = ParseCoverData(RootObject);
         ProjectData.CurrentVars = ParseVariables(RootObject);
         ProjectData.Components = ParseAllComponents(RootObject);
@@ -1477,6 +1478,69 @@ void UArcweaveSubsystem::ParseResponse(const FString& ResponseString)
         // Handle error here.
         UE_LOG(LogArcwarePlugin, Error, TEXT("Project name is invalid!"));
     }
+}
+
+FArcweaveContents UArcweaveSubsystem::ParseAllContents(const TSharedPtr<FJsonObject>& MainJsonObject)
+{
+    FArcweaveContents ParsedContents;
+
+    const TSharedPtr<FJsonObject>* ContentsObject;
+    if (MainJsonObject->TryGetObjectField(TEXT("contents"), ContentsObject))
+    {
+        // Iterate through all entries in the "contents" object
+        for (const auto& ContentPair : ContentsObject->Get()->Values)
+        {
+            FString ContentId = ContentPair.Key;
+            const TSharedPtr<FJsonObject> ContentData = ContentPair.Value->AsObject();
+
+            if (!ContentData.IsValid())
+            {
+                return ParsedContents;
+            }
+
+            FArcweaveContent ArcweaveContent;
+
+            // Parse localized string fields (e.g., label, title, content)
+            for (const auto& FieldPair : ContentData->Values)
+            {
+                FString FieldKey = FieldPair.Key;
+
+                /* For the moment we will ignore status*/
+                if (FieldKey.Compare(TEXT("_status")) == 0)
+                {
+                    continue;
+                }
+                const TSharedPtr<FJsonObject> LocalizedObject = FieldPair.Value->AsObject();
+
+                if (LocalizedObject.IsValid())
+                {
+                    FArcweaveLocalizedText LocalizedText;
+
+                    // Parse translations for each locale
+                    for (const auto& LocalePair : LocalizedObject->Values)
+                    {
+                        FString Locale = LocalePair.Key;
+                        const TSharedPtr<FJsonObject> LocaleData = LocalePair.Value->AsObject();
+
+                        if (LocaleData.IsValid())
+                        {
+                            FString Translation;
+                            if (LocaleData->TryGetStringField(TEXT("text"), Translation))
+                            {
+                                ArcweaveContent.AddTranslationForKey(FieldKey, Translation, FieldKey);
+                            }
+                        }
+                    }
+
+                }
+            }
+
+            // Add the parsed content to the contents map
+            ParsedContents.AddContent(ContentId, ArcweaveContent);
+        }
+    }
+
+    return ParsedContents;
 }
 
 void UArcweaveSubsystem::OnEventCallback(const char* EventName)

--- a/Source/arcweave/Public/ArcweaveContent.h
+++ b/Source/arcweave/Public/ArcweaveContent.h
@@ -22,6 +22,8 @@ struct FArcweaveContent {
 
     void AddTranslationForKey(const FString& Locale, const FString& Translation, const FString& Key);
 
+    void PrintContent() const;
+
 private: 
     /*
     * Will contain value for the content fields (e.g label, title, text)

--- a/Source/arcweave/Public/ArcweaveContent.h
+++ b/Source/arcweave/Public/ArcweaveContent.h
@@ -1,0 +1,32 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+// Plugin include
+#include "ArcweaveLocalizedText.h"
+
+// Engine include
+#include "CoreMinimal.h"
+#include "Containers/Map.h"
+#include "Containers/UnrealString.h"
+#include "JsonObjectConverter.h"
+
+#include "ArcweaveContent.generated.h"
+
+USTRUCT(BlueprintType)
+struct FArcweaveContent {
+
+    GENERATED_BODY()
+
+    bool GetTranslationForKey(FString& OutTranslation, const FString& Locale, const FString& Key) const;
+
+    void AddTranslationForKey(const FString& Locale, const FString& Translation, const FString& Key);
+
+private: 
+    /*
+    * Will contain value for the content fields (e.g label, title, text)
+    */
+    TMap<FString, FArcweaveLocalizedText> LocalizedStringFields;
+
+
+};

--- a/Source/arcweave/Public/ArcweaveContents.h
+++ b/Source/arcweave/Public/ArcweaveContents.h
@@ -1,0 +1,34 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+// Plugin includes
+#include "ArcweaveContent.h"
+
+// Engine includes
+#include "CoreMinimal.h"
+#include "Containers/Map.h"
+#include "Containers/UnrealString.h"
+#include "JsonObjectConverter.h"
+
+// Generated include
+#include "ArcweaveContents.generated.h"
+
+/**
+ * 
+ */
+USTRUCT(BlueprintType)
+struct ARCWEAVE_API FArcweaveContents
+{
+    GENERATED_BODY()
+
+    FArcweaveContent GetContent(const FString& Id) const;
+
+    void AddContent(const FString& ContentKey, const FArcweaveContent& Content);
+
+private:
+    /*
+    * Map containg all the contents of the project, indexed by their id.
+    */
+    TMap<FString, FArcweaveContent> Contents;
+};

--- a/Source/arcweave/Public/ArcweaveContents.h
+++ b/Source/arcweave/Public/ArcweaveContents.h
@@ -22,9 +22,11 @@ struct ARCWEAVE_API FArcweaveContents
 {
     GENERATED_BODY()
 
-    FArcweaveContent GetContent(const FString& Id) const;
+    bool GetContent(FArcweaveContent& OutContent, const FString& Id) const;
 
     void AddContent(const FString& ContentKey, const FArcweaveContent& Content);
+
+    void PrintContents() const;
 
 private:
     /*

--- a/Source/arcweave/Public/ArcweaveContents.h
+++ b/Source/arcweave/Public/ArcweaveContents.h
@@ -30,7 +30,7 @@ struct ARCWEAVE_API FArcweaveContents
 
 private:
     /*
-    * Map containg all the contents of the project, indexed by their id.
+    * Map containing all the contents of the project, indexed by their id.
     */
     TMap<FString, FArcweaveContent> Contents;
 };

--- a/Source/arcweave/Public/ArcweaveLocaleData.h
+++ b/Source/arcweave/Public/ArcweaveLocaleData.h
@@ -17,6 +17,11 @@ struct FArcweaveLocaleData
     UPROPERTY(BlueprintReadWrite, Category = "Arcweave")
     FString Name = FString("");
 
+    bool HasFallbackLanguage() const
+    {
+        return !Base.IsEmpty();
+    }
+
     FArcweaveLocaleData()
         : Iso(FString(""))
         , Base()

--- a/Source/arcweave/Public/ArcweaveLocaleData.h
+++ b/Source/arcweave/Public/ArcweaveLocaleData.h
@@ -1,0 +1,23 @@
+
+#pragma once
+
+USTRUCT(BlueprintType)
+struct FArcweaveLocaleData
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite, Category = "Arcweave")
+    FString Iso = FString("");
+
+    UPROPERTY(BlueprintReadWrite, Category = "Arcweave")
+    FString Base = FString("");
+
+    UPROPERTY(BlueprintReadWrite, Category = "Arcweave")
+    FString Name = FString("");
+
+    FArcweaveLocaleData()
+        : Iso(FString(""))
+        , Base()
+        , Name(FString(""))
+    {}
+};

--- a/Source/arcweave/Public/ArcweaveLocaleData.h
+++ b/Source/arcweave/Public/ArcweaveLocaleData.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "ArcweaveLocaleData.generated.h"
+
 USTRUCT(BlueprintType)
 struct FArcweaveLocaleData
 {

--- a/Source/arcweave/Public/ArcweaveLocaleData.h
+++ b/Source/arcweave/Public/ArcweaveLocaleData.h
@@ -1,6 +1,10 @@
 
 #pragma once
 
+// Engine include
+#include "CoreMinimal.h"
+
+// Generated include
 #include "ArcweaveLocaleData.generated.h"
 
 USTRUCT(BlueprintType)

--- a/Source/arcweave/Public/ArcweaveLocalizedText.h
+++ b/Source/arcweave/Public/ArcweaveLocalizedText.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Engine include
+#include "Containers/Map.h"
+#include "Containers/UnrealString.h"
+
+// Generate include
+#include "ArcweaveLocalizedText.generated.h"
+
+/*
+* This class keeps record of the translation of the arcweave content in
+* the different locales (e.g. en, fr, it...)
+*/
+USTRUCT(BlueprintType)
+struct FArcweaveLocalizedText
+{
+    GENERATED_BODY()
+
+    void AddTranslation(const FString& Locale, const FString& Translation);
+
+    /* 
+    * Try get translation for the defined locale, return false if it can't find anything
+    */
+    bool GetTranslation(FString& OutTranslation, const FString& Locale) const;
+
+private:
+    TMap<FString, FString> TextTranslations;
+};

--- a/Source/arcweave/Public/ArcweaveLocalizedText.h
+++ b/Source/arcweave/Public/ArcweaveLocalizedText.h
@@ -23,6 +23,8 @@ struct FArcweaveLocalizedText
     */
     bool GetTranslation(FString& OutTranslation, const FString& Locale) const;
 
+    void PrintTranslations() const;
+
 private:
     TMap<FString, FString> TextTranslations;
 };

--- a/Source/arcweave/Public/ArcweaveLocalizedText.h
+++ b/Source/arcweave/Public/ArcweaveLocalizedText.h
@@ -3,6 +3,7 @@
 // Engine include
 #include "Containers/Map.h"
 #include "Containers/UnrealString.h"
+#include "CoreMinimal.h"
 
 // Generate include
 #include "ArcweaveLocalizedText.generated.h"

--- a/Source/arcweave/Public/ArcweaveProjectData.h
+++ b/Source/arcweave/Public/ArcweaveProjectData.h
@@ -3,10 +3,12 @@
 // Arcweave includes
 #include "ArcweaveBoardData.h"
 #include "ArcweaveComponentData.h"
-#include "ArcweaveVariable.h"
 #include "ArcweaveConditionData.h"
 #include "ArcweaveConnectionsData.h"
+#include "ArcweaveContents.h"
 #include "ArcweaveCoverData.h"
+#include "ArcweaveVariable.h"
+#include "ArcweaveLocaleData.h"
 
 // Generated include
 #include "ArcweaveProjectData.generated.h"
@@ -46,6 +48,13 @@ struct FArcweaveProjectData
     UPROPERTY(BlueprintReadWrite, Category = "Arcweave")
     TMap<FString, int> Visits = TMap<FString, int>();
     
+    /* Project languages, it can be one so this value is an optional */
+    UPROPERTY(BlueprintReadWrite, Category = "Arcweave")
+    TArray<FArcweaveLocaleData> Locales = TArray<FArcweaveLocaleData>();
+
+    UPROPERTY(BlueprintReadWrite, Category = "Arcweave")
+    FArcweaveContents Contents = FArcweaveContents();
+
     //constructor
     FArcweaveProjectData()
         : Name(FString(""))
@@ -54,5 +63,7 @@ struct FArcweaveProjectData
         , Boards(TArray<FArcweaveBoardData>())
         , Components(TArray<FArcweaveComponentData>())
         , Visits(TMap<FString, int>())
+        , Locales(TArray<FArcweaveLocaleData>())
+        , Contents(FArcweaveContents())
     {}
 };

--- a/Source/arcweave/Public/ArcweaveSettings.h
+++ b/Source/arcweave/Public/ArcweaveSettings.h
@@ -23,19 +23,19 @@ public:
      * Enable to receive the data from local JSON file instead of API.
      * The JSON file and resource files should be located in the Content/ArcweaveExport folder.
      */
-    UPROPERTY(Config, EditAnywhere, Category = ArcweaveSettings)
+    UPROPERTY(Config, EditAnywhere, Category = "ArcweaveSettings")
     bool EnableReceiveMethodFromLocalJSON = false;
 
     /*
      * API token that you can find in your Arcweave account settings.
      */
-    UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "!EnableReceiveMethodFromLocalJSON"), Category = ArcweaveSettings)
+    UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "!EnableReceiveMethodFromLocalJSON"), Category = "ArcweaveSettings")
     FString APIToken = FString("");
 
     /*
      * Project hash that we want to retrieve the information for. You can find it by looking at the URL of your project.
      */
-    UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "!EnableReceiveMethodFromLocalJSON"), Category = ArcweaveSettings)
+    UPROPERTY(Config, EditAnywhere, meta = (EditCondition = "!EnableReceiveMethodFromLocalJSON"), Category = "ArcweaveSettings")
     FString Hash = FString("");
 
     //override post init properties to check if the settings are valid
@@ -49,7 +49,7 @@ public:
 
     void SetUseLocale(bool bValue) { bUseLocale = bValue; }
 
-    FString GetLocale() const { return Locale; }
+    FString GetLocale() const;
 
     void SetLocale(const FString& CustomLocale) { Locale = CustomLocale; }
 
@@ -58,12 +58,12 @@ public:
     void SetFallbackToDefaultLocale(bool bValue) { bFallbackToDefaultLocale = bValue; }
 
 private:
-    UPROPERTY(EditAnywhere, Category = ArcweaveSettings, meta = (ToolTip = "Allow using a custom language for the application if available (e.g. en, it, fr ...)"))
+    UPROPERTY(EditAnywhere, Category = "ArcweaveSettings| Languages", meta = (ToolTip = "Allow using a custom language for the application if available (e.g. en, it, fr ...)"))
     bool bUseLocale = false;
 
 
     UPROPERTY(EditAnywhere,
-        Category = ArcweaveSettings,
+        Category = "ArcweaveSettings| Languages",
         meta = (
             EditCondition = "bUseLocale",
             ToolTip = "Default language used for the application if available (e.g. en, it, fr ...)"
@@ -72,10 +72,10 @@ private:
     FString Locale = FString("fr");
 
     UPROPERTY(EditAnywhere,
-        Category = ArcweaveSettings,
+        Category = "ArcweaveSettings| Languages",
         meta = (
-            EditCondition = "!EnableReceiveMethodFromLocalJSON && bUseLocale",
-            ToolTip = "If the specified language is not available, fallback to the standard language (usually en-us). This option is available only from web api"
+            EditCondition = "bUseLocale",
+            ToolTip = "If the specified language is not available, fallback to the standard language (the one defined for the current locale as base in the app)"
             )
     )
     bool bFallbackToDefaultLocale = true;

--- a/Source/arcweave/Public/ArcweaveSettings.h
+++ b/Source/arcweave/Public/ArcweaveSettings.h
@@ -58,11 +58,18 @@ public:
     void SetFallbackToDefaultLocale(bool bValue) { bFallbackToDefaultLocale = bValue; }
 
 private:
-    UPROPERTY(EditAnywhere, Category = "ArcweaveSettings| Languages", meta = (ToolTip = "Allow using a custom language for the application if available (e.g. en, it, fr ...)"))
+    UPROPERTY(Config,
+        EditAnywhere,
+        Category = "ArcweaveSettings| Languages",
+        meta = (
+            ToolTip = "Allow using a custom language for the application if available (e.g. en, it, fr ...)"
+            )
+    )
     bool bUseLocale = false;
 
 
-    UPROPERTY(EditAnywhere,
+    UPROPERTY(Config,
+        EditAnywhere,
         Category = "ArcweaveSettings| Languages",
         meta = (
             EditCondition = "bUseLocale",
@@ -71,7 +78,8 @@ private:
     )
     FString Locale = FString("fr");
 
-    UPROPERTY(EditAnywhere,
+    UPROPERTY(Config,
+        EditAnywhere,
         Category = "ArcweaveSettings| Languages",
         meta = (
             EditCondition = "bUseLocale",

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -211,7 +211,7 @@ private:
     bool GetBoardObjectForElement(FString ConditionId, FArcweaveConditionData& OutConditionData, FArcweaveBoardData*& OutBoardObj);
     /* Given a locale iso, will look for the corresponding fallback locale*/
     FString GetFallbackLanguageForLocale(const FString& Locale) const;
-    FString GetTranslatedContent(const FString& ContentKey, const FString& FieldName, const FString& CurrentLocale, bool ShouldFallback /* =true */) const;
+    FString GetTranslatedContent(const FString& ContentKey, const FString& FieldName, const FString& CurrentLocale, bool ShouldFallback /*= true*/) const;
     // Helper function to get desired locale and fallback flag from ArcweaveSettings
     void GetLanguageSettings(FString& OutDesiredLocale, bool& OutFallbackToDefaultLanguage);
 

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -35,6 +35,8 @@ class UArcscriptTranspilerWrapper;
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnArcweaveResponseReceived, const FArcweaveProjectData&, ArcweaveProjectData);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnArcweaveVariableChanged, const TArray<FArcweaveVariable>&, ArcweaveVariables);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnArcweaveArcscriptEventReceived, const FString&, EventName);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnArcweaveLanguageChanged, const FString&, DesiredLocale);
+
 UCLASS()
 class ARCWEAVE_API UArcweaveSubsystem : public UEngineSubsystem
 {
@@ -117,6 +119,9 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Arcweave")
     void UpdateVariablesFromConnection(const FArcweaveConnectionsData& Connection);
 
+    /* Update the language of the boards with the specified desired locale (e.g. "en", "fr"..) */
+    UFUNCTION(BlueprintCallable, Category = "Arcweave| Languages")
+    void UpdateContentsWithLocale(const FString& DesiredLocale);
     /*
      * Check if the target is the branch
      */    
@@ -148,6 +153,9 @@ public:
 
     UPROPERTY(BlueprintAssignable, Category = "Arcweave")
     FOnArcweaveArcscriptEventReceived OnArcscriptEventReceived;
+
+    UPROPERTY(BlueprintAssignable, Category = "Arcweave| Languages")
+    FOnArcweaveLanguageChanged OnArcweaveLanguageChanged;
 
 protected:
     //override init function

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -201,6 +201,12 @@ private:
     FArcweaveConnectionsData TryGetNExtConnectionData(const FArcweaveBoardData& BoardData, const FArcweaveBranchData& Branch, const FArcweaveConditionData* FiredConditionData);
     void LogTranspilerOutput(const FArcscriptTranspilerOutput& TranspilerOutput);
     bool GetBoardObjectForElement(FString ConditionId, FArcweaveConditionData& OutConditionData, FArcweaveBoardData*& OutBoardObj);
+    /* Given a locale iso, will look for the corresponding fallback locale*/
+    FString GetFallbackLanguageForLocale(const FString& Locale) const;
+    FString GetTranslatedContent(const FString& ContentKey, const FString& FieldName, const FString& CurrentLocale, bool ShouldFallback /* =true */) const;
+    // Helper function to get desired locale and fallback flag from ArcweaveSettings
+    void GetLanguageSettings(FString& OutDesiredLocale, bool& OutFallbackToDefaultLanguage);
+
     /* Increment visit counter for the given element id*/
     void IncrementVisits(const FString& ElementId);
     void ResetVisits();

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -191,6 +191,7 @@ private:
     /** Looks for the locales configuration in the project and try to parse it */
     TArray<FArcweaveLocaleData> ParseProjectLocales(const TSharedPtr<FJsonObject>& MainJsonObject);
     void ParseResponse(const FString& ResponseString);
+    FArcweaveContents ParseAllContents(const TSharedPtr<FJsonObject>& MainJsonObject);
     void OnEventCallback(const char* EventName);
     FArcscriptTranspilerOutput RunTranspiler(const FString& NodeCode, const FString& OriginElementId,
         const TMap<FString, FArcweaveVariable>& InitialVars, const TMap<FString, int>& Visits, bool bShouldUpdateVariables = true);
@@ -208,12 +209,11 @@ private:
 
     UFUNCTION(BlueprintCallable, Category = "Arcweave | Debug")
     void PrintBranchData(const FArcweaveBranchData &InData);
+
 private:
     UPROPERTY()
     FArcweaveProjectData ProjectData = FArcweaveProjectData();
     UPROPERTY()
     FArcweaveBoardData BoardObj = FArcweaveBoardData();
-    /*UPROPERTY()
-    FArcweaveAPISettings ArcweaveAPISettings = FArcweaveAPISettings();*/
 
 };

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -216,6 +216,8 @@ private:
     /* Given a locale iso, will look for the corresponding fallback locale*/
     FString GetFallbackLanguageForLocale(const FString& Locale) const;
     FString GetTranslatedContent(const FString& ContentKey, const FString& FieldName, const FString& CurrentLocale, bool ShouldFallback /*= true*/) const;
+    /* Tries to find a fallback translation for the specified content and locale*/
+    FString TryToFindFallbackTranslation(const struct FArcweaveContent& Content, const FString& FieldName, const FString& CurrentLocale) const;
     // Helper function to get desired locale and fallback flag from ArcweaveSettings
     void GetLanguageSettings(FString& OutDesiredLocale, bool& OutFallbackToDefaultLanguage);
 

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -189,7 +189,8 @@ private:
     TArray<FArcweaveConnectionsData> ParseAllConnections(const TSharedPtr<FJsonObject>& MainJsonObject);
     FArcweaveCoverData ParseCoverData(const TSharedPtr<FJsonObject>& CoverValueObject);
     /** Looks for the locales configuration in the project and try to parse it */
-    TArray<FArcweaveLocaleData> ParseLocales(const TSharedPtr<FJsonObject>& MainJsonObject);
+    TArray<FArcweaveLocaleData> ParseProjectLocales(const TSharedPtr<FJsonObject>& MainJsonObject);
+    FArcweaveLocalizedText ParseElementTranslations(const TSharedPtr<FJsonObject> ComponentValueObject,const FStringView& FieldName);
     void ParseResponse(const FString& ResponseString);
     void OnEventCallback(const char* EventName);
     FArcscriptTranspilerOutput RunTranspiler(const FString& NodeCode, const FString& OriginElementId,

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -190,7 +190,6 @@ private:
     FArcweaveCoverData ParseCoverData(const TSharedPtr<FJsonObject>& CoverValueObject);
     /** Looks for the locales configuration in the project and try to parse it */
     TArray<FArcweaveLocaleData> ParseProjectLocales(const TSharedPtr<FJsonObject>& MainJsonObject);
-    FArcweaveLocalizedText ParseElementTranslations(const TSharedPtr<FJsonObject> ComponentValueObject,const FStringView& FieldName);
     void ParseResponse(const FString& ResponseString);
     void OnEventCallback(const char* EventName);
     FArcscriptTranspilerOutput RunTranspiler(const FString& NodeCode, const FString& OriginElementId,

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -188,6 +188,8 @@ private:
     TArray<FArcweaveConditionData> ParseAllConditions(const TSharedPtr<FJsonObject>& MainJsonObject);
     TArray<FArcweaveConnectionsData> ParseAllConnections(const TSharedPtr<FJsonObject>& MainJsonObject);
     FArcweaveCoverData ParseCoverData(const TSharedPtr<FJsonObject>& CoverValueObject);
+    /** Looks for the locales configuration in the project and try to parse it */
+    TArray<FArcweaveLocaleData> ParseLocales(const TSharedPtr<FJsonObject>& MainJsonObject);
     void ParseResponse(const FString& ResponseString);
     void OnEventCallback(const char* EventName);
     FArcscriptTranspilerOutput RunTranspiler(const FString& NodeCode, const FString& OriginElementId,

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -104,7 +104,11 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "Arcweave")
     FArcscriptTranspilerOutput TranspileCondition(const FString& ConditionId, const FString& OriginElementId, bool& Success);
+    /* Given an element id, get it's board */
     bool GetBoardForObject(FString ObjectId, FArcweaveElementData& OutElement, FArcweaveBoardData*& OutBoardObj);
+    /* Given a board id it will get the board object*/
+    UFUNCTION(BlueprintCallable, Category = "Arcweave")
+    bool GetBoard(FArcweaveBoardData& OutBoardObj, const FString& BoardId);
     /* Given a condition Id (e.g. if visit()) gets the corresponding branch id */
     bool GetBranchForObject(FArcweaveBranchData& OutBranch, const FString& ObjectId, const FArcweaveBoardData& InBoardObj) const;
 

--- a/Source/arcweave/Public/ArcweaveSubsystem.h
+++ b/Source/arcweave/Public/ArcweaveSubsystem.h
@@ -23,6 +23,8 @@
 #include "Serialization/JsonSerializer.h"
 #include "Subsystems/EngineSubsystem.h"
 
+
+// Generated include
 #include "ArcweaveSubsystem.generated.h"
 
 struct FArcweaveAPISettings;
@@ -70,6 +72,10 @@ public:
      */
     UFUNCTION(BlueprintPure, Category = "Arcweave")
     FArcweaveProjectData GetArcweaveProjectData() const {return ProjectData;};
+
+    /** Return true if in the project config has more than one language/locale */
+    UFUNCTION(BlueprintPure, Category = "Arcweave")
+    bool HasLocales() const;
 
     /*
      * Run transpiler for the element


### PR DESCRIPTION
# WHAT 
This pull request allows handling multiple languages at runtime from a json containing locales.
These are defined in the json that are exported from the web api using the option "All languages". This feature can be enabled saving a json with more than one locale inside the folder "Content/ArcweaveExport" and going into the arcweave  settings "Edit>ProjectSettings" filter by "Arcweave" and set "Use Locale" to true.

If you want to switch from one language to another use the method 
```cpp 
    void UpdateContentsWithLocale(const FString& DesiredLocale);
```

## WHY
This will allow switching between languages even without internet connection or with one API call (still to be implemented) for internet limited applications. 

### Tested using 
[project.json](https://github.com/user-attachments/files/26246636/project.json)

### To test it
- checkout on branch "showcase-multiple-locale" in the unreal example repo
- inside the plugins folder switch the submodule branch to "test/multiple-languages-support"
- copy the file attached inside Unreal "ArcweaveExportFolder" and set the settings preferences to use "import from json"

If you set the language to french you will see the first dialogues in French, and when them are not available they will be shown in the fallback locale language "en"
