### PR TITLE
Fix Mac dylib staging and runtime loading path for packaged builds

### DIFF
--- a/Source/ThirdParty/ArcscriptTranspiler/ArcscriptTranspiler.Build.cs
+++ b/Source/ThirdParty/ArcscriptTranspiler/ArcscriptTranspiler.Build.cs
@@ -28,14 +28,17 @@ public class ArcscriptTranspiler : ModuleRules
             // we add the dylib to the list of libraries to link against.
             PublicAdditionalLibraries.Add(DylibPath);
 
-            // Ask UE's ModuleManager to try to load the dylib at runtime as well so
-            // that it is available both in the editor and in packaged builds.
-            PublicDelayLoadDLLs.Add(DylibPath);
+            // Stage the dylibs to the plugin's Binaries/Mac folder, which is the
+            // standard UE location for plugin binaries and where arcweave.cpp loads
+            // them from at runtime. The single-argument form of RuntimeDependencies
+            // would copy to the wrong location in packaged builds.
+            string OutputDir = Path.Combine(PluginDirectory, "Binaries", "Mac");
+            RuntimeDependencies.Add(Path.Combine(OutputDir, "libArcscriptTranspiler.dylib"), DylibPath);
+            RuntimeDependencies.Add(Path.Combine(OutputDir, "libantlr4-runtime.dylib"), Antlr4DylibPath);
 
-            // Finally stage the library so it is copied next to the packaged
-            // application / plugin.
-            RuntimeDependencies.Add(DylibPath);
-            RuntimeDependencies.Add(Antlr4DylibPath);
+            // Also stage to the target output directory for packaged game builds.
+            RuntimeDependencies.Add("$(BinaryOutputDir)/libArcscriptTranspiler.dylib", DylibPath);
+            RuntimeDependencies.Add("$(BinaryOutputDir)/libantlr4-runtime.dylib", Antlr4DylibPath);
         }
 
         PublicIncludePaths.AddRange(new string[]

--- a/Source/arcweave/Private/arcweave.cpp
+++ b/Source/arcweave/Private/arcweave.cpp
@@ -29,7 +29,7 @@ void FarcweaveModule::StartupModule()
     FPlatformProcess::AddDllDirectory(*FPaths::Combine(*BaseDir, TEXT("/Source/ThirdParty/ArcscriptTranspiler/lib")));
     ArcscriptTranspilerPath = FPaths::Combine(*BaseDir, TEXT("/Source/ThirdParty/ArcscriptTranspiler/lib/ArcscriptTranspiler.dll"));
 #elif PLATFORM_MAC
-    ArcscriptTranspilerPath = FPaths::Combine(*BaseDir, TEXT("/Source/ThirdParty/ArcscriptTranspiler/lib/libArcscriptTranspiler.dylib"));
+    ArcscriptTranspilerPath = FPaths::Combine(*BaseDir, TEXT("Binaries/Mac/libArcscriptTranspiler.dylib"));
 	#elif PLATFORM_LINUX
 	//Antlr4LibraryPath = FPaths::Combine(*BaseDir, TEXT("Binaries/ThirdParty/arcweaveLibrary/Linux/x86_64-unknown-linux-gnu/libExampleLibrary.so"));
 	#endif // PLATFORM_WINDOWS


### PR DESCRIPTION
Packaged builds on Mac had 3 issues:
-  RuntimeDependencies staging to the wrong place: the single-argument form preserves the source-relative path, so the dylib ends up in Source/ThirdParty/ which didn't exist in packaged builds.
- Switched to explicit destination paths: Plugins/arcweave/Binaries/Mac/ and $(BinaryOutputDir).
- Also fixed arcweave.cpp: now loads from Binaries/Mac
- Removed publicDelayLoadDLLs since it's a Windows only feature (didn't do anything "wrong" but turns out it was inactive - removed it to avoid red herrings)

Confirmed end-to-end: packaged a Development build from a clean slate, ran it, dylib loaded correctly and it properly parsed an arcweave json file. Also confirmed it didn't break the editor's version.