### PR TITLE
[Feature] Add custom editable json path

### DIFF
--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -91,8 +91,17 @@ void UArcweaveSubsystem::FetchData(FString APIToken, FString ProjectHash)
 
 bool UArcweaveSubsystem::LoadJsonFile()
 {
+    const FArcweaveAPISettings ArcweaveAPISettings = LoadArcweaveSettings();
+
+    if (ArcweaveAPISettings.JsonFilePath.IsEmpty())
+    {
+        FString Message = FString::Printf(TEXT("Json file path is empty in settings!"));
+        LogFetchStatus(true, Message);
+        return false;
+    }
+
     FString JsonRaw;
-    FString DirectoryPath = FPaths::ProjectDir() + TEXT("Content/ArcweaveExport/");
+    FString DirectoryPath = FPaths::ProjectDir() + ArcweaveAPISettings.JsonFilePath;
     // Normalize the directory path
     FPaths::NormalizeDirectoryName(DirectoryPath);
     // Get the file manager instance
@@ -147,6 +156,16 @@ FArcweaveAPISettings UArcweaveSubsystem::LoadArcweaveSettings() const
             if (GConfig->GetString(ARCWEAVE_SETTINGS_SECTION, TEXT("Hash"), OutSetttings.Hash, GGameIni))
             {
                 UE_LOG(LogTemp, Warning, TEXT("Read Hash: %s"), *OutSetttings.Hash);
+            }
+
+            if (GConfig->GetString(ARCWEAVE_SETTINGS_SECTION, TEXT("JsonFilePath"), OutSetttings.JsonFilePath, GGameIni))
+            {
+                UE_LOG(LogTemp, Warning, TEXT("Read JsonFilePath: %s"), *OutSetttings.JsonFilePath);
+            }
+
+            if (GConfig->GetString(ARCWEAVE_SETTINGS_SECTION, TEXT("JsonFilePath"), OutSetttings.JsonFilePath, GGameIni))
+            {
+                UE_LOG(LogTemp, Warning, TEXT("Read JsonFilePath: %s"), *OutSetttings.JsonFilePath);
             }
 
             if (GConfig->GetBool(ARCWEAVE_SETTINGS_SECTION, TEXT("bUseLocale"), OutSetttings.bUseLocale, GGameIni))

--- a/Source/arcweave/Private/ArcweaveSubsystem.cpp
+++ b/Source/arcweave/Private/ArcweaveSubsystem.cpp
@@ -93,15 +93,18 @@ bool UArcweaveSubsystem::LoadJsonFile()
 {
     const FArcweaveAPISettings ArcweaveAPISettings = LoadArcweaveSettings();
 
-    if (ArcweaveAPISettings.JsonFilePath.IsEmpty())
+    if (ArcweaveAPISettings.JsonDirectoryPath.IsEmpty())
     {
-        FString Message = FString::Printf(TEXT("Json file path is empty in settings!"));
-        LogFetchStatus(true, Message);
+        FString Message = FString::Printf(TEXT("Json directory path is empty in settings!"));
+        LogFetchStatus(false, Message);
         return false;
     }
 
     FString JsonRaw;
-    FString DirectoryPath = FPaths::ProjectDir() + ArcweaveAPISettings.JsonFilePath;
+    FString DirectoryPath = FPaths::IsRelative(ArcweaveAPISettings.JsonDirectoryPath)
+        ? FPaths::Combine(FPaths::ProjectDir(), ArcweaveAPISettings.JsonDirectoryPath)
+        : ArcweaveAPISettings.JsonDirectoryPath;
+
     // Normalize the directory path
     FPaths::NormalizeDirectoryName(DirectoryPath);
     // Get the file manager instance
@@ -117,19 +120,22 @@ bool UArcweaveSubsystem::LoadJsonFile()
         FString Message = FString::Printf(TEXT("Found file: %s"), *File);
         LogFetchStatus(true, Message);
     }
+    
     //always get the 0 one if there are mutiple ones
     if (Files.IsValidIndex(0) == false)
     {
-        FString Message = FString::Printf(TEXT("There is no JSON folder in the ArcweaveExport directory!"));
-        LogFetchStatus(true, Message);
+        FString Message = FString::Printf(TEXT("There is no JSON folder in the %s directory!"), *DirectoryPath);
+        LogFetchStatus(false, Message);
         return false;
     }
+
     if (!FFileHelper::LoadFileToString(JsonRaw, *Files[0]))
     {
         FString Message = FString::Printf(TEXT("Failed to load JSON file!"));
-        LogFetchStatus(true, Message);
+        LogFetchStatus(false, Message);
         return false;
     }
+
     ParseResponse(JsonRaw);
     return true;
 }
@@ -158,14 +164,9 @@ FArcweaveAPISettings UArcweaveSubsystem::LoadArcweaveSettings() const
                 UE_LOG(LogTemp, Warning, TEXT("Read Hash: %s"), *OutSetttings.Hash);
             }
 
-            if (GConfig->GetString(ARCWEAVE_SETTINGS_SECTION, TEXT("JsonFilePath"), OutSetttings.JsonFilePath, GGameIni))
+            if (GConfig->GetString(ARCWEAVE_SETTINGS_SECTION, TEXT("JsonDirectoryPath"), OutSetttings.JsonDirectoryPath, GGameIni))
             {
-                UE_LOG(LogTemp, Warning, TEXT("Read JsonFilePath: %s"), *OutSetttings.JsonFilePath);
-            }
-
-            if (GConfig->GetString(ARCWEAVE_SETTINGS_SECTION, TEXT("JsonFilePath"), OutSetttings.JsonFilePath, GGameIni))
-            {
-                UE_LOG(LogTemp, Warning, TEXT("Read JsonFilePath: %s"), *OutSetttings.JsonFilePath);
+                UE_LOG(LogTemp, Warning, TEXT("Read JsonDirectoryPath: %s"), *OutSetttings.JsonDirectoryPath);
             }
 
             if (GConfig->GetBool(ARCWEAVE_SETTINGS_SECTION, TEXT("bUseLocale"), OutSetttings.bUseLocale, GGameIni))

--- a/Source/arcweave/Public/ArcweaveAPISettings.h
+++ b/Source/arcweave/Public/ArcweaveAPISettings.h
@@ -37,7 +37,7 @@ struct FArcweaveAPISettings
             ToolTip = "Insert the folder path containing the .json file"
             )
     )
-    FString JsonFilePath = FString("Content/ArcweaveExport/");
+    FString JsonDirectoryPath = FString("Content/ArcweaveExport/");
 
 
 #pragma region Language

--- a/Source/arcweave/Public/ArcweaveAPISettings.h
+++ b/Source/arcweave/Public/ArcweaveAPISettings.h
@@ -29,6 +29,17 @@ struct FArcweaveAPISettings
 	UPROPERTY(BlueprintReadWrite, Category = "Arcweave| Settings")
 	FString Hash = FString("");
 
+    UPROPERTY(
+        BlueprintReadWrite,
+        Category = "Arcweave| Settings",
+        meta = (
+            EditCondition = "EnableReceiveMethodFromLocalJSON",
+            ToolTip = "Insert the folder path containing the .json file"
+            )
+    )
+    FString JsonFilePath = FString("Content/ArcweaveExport/");
+
+
 #pragma region Language
 
     UPROPERTY(BlueprintReadWrite, Category = "Arcweave| Settings", meta = (ToolTip = "Allow using a custom language for the application if available (e.g. en, it, fr ...)"))

--- a/Source/arcweave/Public/ArcweaveSettings.h
+++ b/Source/arcweave/Public/ArcweaveSettings.h
@@ -26,6 +26,17 @@ public:
     UPROPERTY(Config, EditAnywhere, Category = ArcweaveSettings)
     bool EnableReceiveMethodFromLocalJSON = false;
 
+    UPROPERTY(
+        Config,
+        EditAnywhere,
+        meta = (
+            EditCondition = "EnableReceiveMethodFromLocalJSON",
+            ToolTip = "Insert the folder path containing the .json file"
+            ),
+        Category = ArcweaveSettings
+    )
+    FString JsonFilePath = FString("Content/ArcweaveExport/");
+
     /*
      * API token that you can find in your Arcweave account settings.
      */
@@ -40,7 +51,6 @@ public:
 
     //override post init properties to check if the settings are valid
     virtual void PostInitProperties() override;
-
 
 #pragma region Language
 
@@ -58,25 +68,33 @@ public:
     void SetFallbackToDefaultLocale(bool bValue) { bFallbackToDefaultLocale = bValue; }
 
 private:
-    UPROPERTY(EditAnywhere, Category = ArcweaveSettings, meta = (ToolTip = "Allow using a custom language for the application if available (e.g. en, it, fr ...)"))
+    UPROPERTY(
+        Config,
+        EditAnywhere,
+        meta = (ToolTip = "Allow using a custom language for the application if available (e.g. en, it, fr ...)"),
+        Category = ArcweaveSettings
+        )
     bool bUseLocale = false;
 
-
-    UPROPERTY(EditAnywhere,
-        Category = ArcweaveSettings,
+    UPROPERTY(
+        Config,
+        EditAnywhere,
         meta = (
             EditCondition = "bUseLocale",
             ToolTip = "Default language used for the application if available (e.g. en, it, fr ...)"
-            )
+            ),
+        Category = ArcweaveSettings
     )
     FString Locale = FString("fr");
 
-    UPROPERTY(EditAnywhere,
-        Category = ArcweaveSettings,
+    UPROPERTY(
+        Config,
+        EditAnywhere,
         meta = (
             EditCondition = "!EnableReceiveMethodFromLocalJSON && bUseLocale",
             ToolTip = "If the specified language is not available, fallback to the standard language (usually en-us). This option is available only from web api"
-            )
+            ),
+        Category = ArcweaveSettings
     )
     bool bFallbackToDefaultLocale = true;
 

--- a/Source/arcweave/Public/ArcweaveSettings.h
+++ b/Source/arcweave/Public/ArcweaveSettings.h
@@ -21,7 +21,7 @@ public:
 
     /*
      * Enable to receive the data from local JSON file instead of API.
-     * The JSON file and resource files should be located in the Content/ArcweaveExport folder.
+     * The JSON file and resource files should be located in the JsonDirectoryPath folder.
      */
     UPROPERTY(Config, EditAnywhere, Category = ArcweaveSettings)
     bool EnableReceiveMethodFromLocalJSON = false;
@@ -31,11 +31,11 @@ public:
         EditAnywhere,
         meta = (
             EditCondition = "EnableReceiveMethodFromLocalJSON",
-            ToolTip = "Insert the folder path containing the .json file"
+            ToolTip = "Insert the folder path relative to the project folder containing the .json file"
             ),
         Category = ArcweaveSettings
     )
-    FString JsonFilePath = FString("Content/ArcweaveExport/");
+    FString JsonDirectoryPath = FString("Content/ArcweaveExport/");
 
     /*
      * API token that you can find in your Arcweave account settings.


### PR DESCRIPTION
# ABOUT
Add custom path for json that can be edited from "ProjectSettings>Plugin>Arcweave", and add "config" keyword to the language fields.

## WHY
- Having the possibility to set the import path adds flexibility to the project, and allows moving the path from a folder in "Content" to one outside of it or a custom path. 
- The keyword "config" in the Unreal header, just above the variable, allows the settings to appear under "Project Settings" and to be saved in a ".ini" ffile

## How to test it
- *Test1* (This test will make the plugin work also in the build) Put the json downloaded from the arcweave application in another folder inside "Content", let's call it "A". Then go in  "ProjectSettings>Plugin>Arcweave" and insert the directory path "Content/A/". Everything should still work as expected. Try to build and check that everything still works and the json is read correctly
- *Test2* put the json outside the "Content" folder in a path that you desire. Everything should still work, but beware that this won't work in build. The feature is still good since any file outside "Content" won't be seen for Unreal as an asset (you won't see the disturbing pop-up at the beginning), and it's a choice that can be followed for a project that the user know that will never ship while we find a better solution to handle this "issue"
